### PR TITLE
Kvs definie comme variable globale dans le main

### DIFF
--- a/kvs.c
+++ b/kvs.c
@@ -10,7 +10,7 @@ uint32_t taille_kvs = 0;
 
 //typedef struct element** KVS ;
 
-KVS *kvs = NULL ;
+KVS *kvs = NULL ; // kvs sera pointé sur le kvs_ définie dans le main et passé en paramètres dans la fonction initiliser().
 
 int initialiser_kvs (const int N , KVS * kvs_) {
   printf("%s\n" , "Initialisation");


### PR DESCRIPTION
Notre Kvs on la définie comme variable globale dans le main et est initialisé à NULL, puis passé en paramètres avec la taille de la table dans la gonction initialiser.
Est ce que notte problème résulte dans le faite de déclarer un variable globale dans le kvs.c et de lui associer l'adresse de notre kvs, c'est la solution qu'on a adoptée pour que get et set peuvent manipuler le Kvs au lieu de passer celui ci en paramètres comme on l a fait la premeir fois ?